### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-all: \
-	install \
-	run
+all: install
 
 run:
 	venv/bin/python wordle.py


### PR DESCRIPTION
Now when you run `make` it won't immediately run the script, it will only install the dependencies. You now have to use `make run` to run the script via the Makefile.